### PR TITLE
fix: OOMSPE-792 Exporter protocol options

### DIFF
--- a/internal/config/monitoring.go
+++ b/internal/config/monitoring.go
@@ -2,12 +2,13 @@ package config // import "github.com/FlyrInc/flyr-lib-go/internal/config"
 
 type MonitoringConfig interface {
 	Service() string
-	ExporterProtocol() string
+	ExporterTracesProtocol() string
 }
 
 type Monitoring struct {
-	ServiceCfg          string `env:"OTEL_SERVICE_NAME"`
-	ExporterProtocolCfg string `env:"OTEL_EXPORTER_OTLP_PROTOCOL"` // http or grpc
+	ServiceCfg               string `env:"OTEL_SERVICE_NAME"`
+	ExporterProtocolCfg      string `env:"OTEL_EXPORTER_OTLP_PROTOCOL"`        // Specifies the OTLP transport protocol to be used for all telemetry data.
+	ExporterTraceProtocolCfg string `env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"` // Specifies the OTLP transport protocol to be used for trace data.
 }
 
 func NewMonitoringConfig(opts ...Option) Monitoring {
@@ -23,7 +24,12 @@ func (d Monitoring) Service() string {
 	return d.ServiceCfg
 }
 
-// ExporterProtocol returns the protocol used by the OTLP exporter.
-func (d Monitoring) ExporterProtocol() string {
+// ExporterTracesProtocol returns the protocol used by the OTLP Trace exporter.
+func (d Monitoring) ExporterTracesProtocol() string {
+	if d.ExporterTraceProtocolCfg != "" {
+		return d.ExporterTraceProtocolCfg
+	}
+
+	// if the trace protocol is not set, use the general exporter protocol
 	return d.ExporterProtocolCfg
 }

--- a/monitoring/tracer/traceprovider.go
+++ b/monitoring/tracer/traceprovider.go
@@ -32,11 +32,17 @@ var (
 
 // getExporterClient returns an OTLP exporter client based on the exporter protocol.
 // If the exporter protocol is not supported, it returns nil.
+//
+// Valid values are:
+//
+// - grpc to use OTLP/gRPC
+//
+// - http/protobuf to use OTLP/HTTP + protobuf
 func getExporterClient(cfg config.MonitoringConfig) otlptrace.Client {
-	switch cfg.ExporterProtocol() {
+	switch cfg.ExporterTracesProtocol() {
 	case "grpc":
 		return otlptracegrpc.NewClient()
-	case "http":
+	case "http/protobuf":
 		return otlptracehttp.NewClient()
 	default:
 		return nil
@@ -78,7 +84,7 @@ func initializeTracerProvider(ctx context.Context, cfg config.MonitoringConfig) 
 		resource.WithContainer(),
 		resource.WithHost(),
 		resource.WithAttributes(
-			attribute.String(config.EXPORTER_PROTOCOL, cfg.ExporterProtocol()),
+			attribute.String(config.EXPORTER_PROTOCOL, cfg.ExporterTracesProtocol()),
 		),
 	)
 	if err != nil {

--- a/monitoring/tracer/traceprovider_test.go
+++ b/monitoring/tracer/traceprovider_test.go
@@ -15,7 +15,7 @@ func getMonitoringConfig() config.Monitoring {
 
 	cfg := config.NewMonitoringConfig()
 	cfg.ServiceCfg = serviceName
-	cfg.ExporterProtocolCfg = "http"
+	cfg.ExporterProtocolCfg = "grpc"
 
 	return cfg
 }
@@ -30,7 +30,7 @@ func TestGetExporterClient(t *testing.T) {
 	})
 
 	t.Run("ReturnsHTTPClient", func(t *testing.T) {
-		cfg.ExporterProtocolCfg = "http"
+		cfg.ExporterProtocolCfg = "http/protobuf"
 		client := getExporterClient(cfg)
 		require.NotNil(t, client)
 	})


### PR DESCRIPTION
Fixes the Otel exporter protocol value value for `http` to `http/protobuf`, as this is the correct one. Also, enables the option for a custom Tracer endpoint using the environment variable `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`. This value takes precedence over `OTEL_EXPORTER_OTLP_PROTOCOL`.