### PR TITLE
ci: configure renovate to match otel semantic versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,19 @@
       ],
       "groupSlug": "otel",
       "matchPackageNames": [
-        "go.opentelemetry.io/**"
+        "go.opentelemetry.io/otel/**"
+      ],
+      "semanticCommitScope": "{{otel-deps}}",
+      "semanticCommitType": "{{#if isPatch}}fix{{else}}feat{{/if}}"
+    },
+    {
+      "groupName": "otel-contrib",
+      "matchDatasources": [
+        "go"
+      ],
+      "groupSlug": "otel-contrib",
+      "matchPackageNames": [
+        "go.opentelemetry.io/contrib/**"
       ],
       "semanticCommitScope": "{{otel-deps}}",
       "semanticCommitType": "{{#if isPatch}}fix{{else}}feat{{/if}}"


### PR DESCRIPTION
This should configure renovate so that a patch version of open telemetry will result in a patch for our package, and a minor version bump will result in a minor version bump of our package.