### PR TITLE
ci: configure renovate to also update the examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,5 +66,6 @@
   "labels": [
     "dependencies"
   ],
+  "ignorePresets": [":ignoreModulesAndTests"],
   "separateMinorPatch": true
 }


### PR DESCRIPTION
This should tell renovate to not ignore the packages in the `examples` anymore. See https://docs.renovatebot.com/presets-default/#ignoremodulesandtests.