### PR TITLE
fix: Nil spans

### DIFF
--- a/internal/span/span.go
+++ b/internal/span/span.go
@@ -36,6 +36,10 @@ type Span struct {
 
 // EndWithError ends the span by updating the status to Error and recording the error
 func (s *Span) EndWithError(err error) {
+	if s.Span == nil {
+		return
+	}
+
 	if err != nil {
 		s.SetStatus(otelcodes.Error, err.Error())
 		s.RecordError(err)
@@ -45,6 +49,10 @@ func (s *Span) EndWithError(err error) {
 
 // EndSuccessfully ends the span by updating the status to Ok
 func (s *Span) EndSuccessfully() {
+	if s.Span == nil {
+		return
+	}
+
 	s.SetStatus(otelcodes.Ok, "")
 	s.End()
 }

--- a/internal/span/span_test.go
+++ b/internal/span/span_test.go
@@ -71,3 +71,13 @@ func TestEndSuccessfully(t *testing.T) {
 	assert.Equal(t, codes.Ok, fakeSpan.FakeStatus.Code)
 	assert.Equal(t, "", fakeSpan.FakeStatus.Description)
 }
+
+func TestEndingZeroSpanDoesntPanic(t *testing.T) {
+	defer func() {
+		require.Nil(t, recover())
+	}()
+
+	s := Span{}
+	s.EndSuccessfully()
+	s.EndWithError(nil)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,5 +23,5 @@
 package version // import "github.com/FLYR-Open-Source/flyr-lib-go/internal/version"
 
 func Version() string {
-	return "v1.1.1" // Hardcoded for now
+	return "v1.2.0" // Hardcoded for now
 }

--- a/monitoring/tracer/spans.go
+++ b/monitoring/tracer/spans.go
@@ -43,10 +43,6 @@ type KeyValue = attribute.KeyValue
 //
 // It returns the new context and the new span
 func StartSpan(ctx context.Context, name string, kind SpanKind) (context.Context, span.Span) {
-	if defaultTracer == nil {
-		return ctx, span.Span{}
-	}
-
 	return defaultTracer.StartSpan(ctx, name, kind)
 }
 

--- a/monitoring/tracer/tracer.go
+++ b/monitoring/tracer/tracer.go
@@ -48,7 +48,9 @@ type Tracer struct {
 // defaultTracer is the default tracer used by the application.
 //
 // The default tracer is initialized by the tracer.StartDefaultTracer(...) function.
-var defaultTracer *Tracer
+var defaultTracer *Tracer = &Tracer{
+	tracer: noop.Tracer{},
+}
 
 // StartDefaultTracer initializes and starts the default OpenTelemetry Tracer.
 //


### PR DESCRIPTION
Initialises `defaultTracer.tracer` to `noop.Tracer{}`, which removes the `nil` validation checks that can be easily be forgotten if we need to use defaultTracer around the library. Furthermore, checks in `EndWithError` and `EndSuccessfully` if the `Span` is nil, which caused trouble when the library was used in unit tests without initialising a TracerProvider.