### PR TITLE
ci: auto-merge minor and patch renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,15 @@
       "enabled": true
     },
     {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "minimumReleaseAge": "7 days",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
Configure renovate to auto-merge `minor` and `patch` updates. Also gives a grace period of a week before doing to ensure no issues exist on the new versions