### PR TITLE
ci: New release on otel deps upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,16 @@ on:
         required: true
         type: boolean
         default: false
+  push: # also trigger automatically when Renovate merges an otel-deps upgrade
+    branches:
+      - main
 
 jobs:
   release:
     name: Release
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '(otel-deps)'))
     uses: ./.github/workflows/semantic-release.yaml
     permissions:
       contents: write # to create GitHub release (cycjimmy/semantic-release-action)

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,7 @@
       ],
       "groupSlug": "otel",
       "matchPackageNames": [
+        "go.opentelemetry.io/otel",
         "go.opentelemetry.io/otel/**"
       ],
       "semanticCommitScope": "otel-deps",


### PR DESCRIPTION
Create a new release automatically when Renovate merges a PR that upgrades otel dependencies.

Do not merge until we have e2e tests to verify the version changes do not break the functionality